### PR TITLE
Add the ability to read from stdin

### DIFF
--- a/cowsay/__main__.py
+++ b/cowsay/__main__.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 from . import CowsayError, char_names, char_funcs, __version__
 
@@ -15,7 +16,7 @@ def cli():
                         default='cow')
 
     parser.add_argument('-t', '--text',
-                        required=True)
+                        help='Text to display. If not provided, reads from stdin.')
 
     parser.add_argument('-v', '--version',
                         action='version', version=__version__)
@@ -25,7 +26,14 @@ def cli():
     if args.character not in char_names:
         raise CowsayError(f'Available Characters: {char_names}')
 
-    char_funcs[args.character](args.text)
+    if args.text:
+        text = args.text
+    else:
+        if sys.stdin.isatty():
+            parser.error('Text argument is required if not piping input.')
+        text = sys.stdin.read().strip()
+
+    char_funcs[args.character](text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request includes several changes to the `cowsay/__main__.py` file to enhance its functionality and improve user experience. The most important changes include adding support for reading input from stdin, updating the argument parser to provide better help messages, and handling cases where the text argument is not provided.

Enhancements to input handling:

* [`cowsay/__main__.py`](diffhunk://#diff-898918360d4f861285544ed3eafde3c1fbc36d5b2c7a79512aa35c704b7786f5R2): Added `sys` import to support reading from stdin.
* [`def cli()`](diffhunk://#diff-898918360d4f861285544ed3eafde3c1fbc36d5b2c7a79512aa35c704b7786f5L18-R19): Updated the `--text` argument to read from stdin if not provided and added a help message for clarity.
* [`def cli()`](diffhunk://#diff-898918360d4f861285544ed3eafde3c1fbc36d5b2c7a79512aa35c704b7786f5L28-R37): Implemented logic to check if input is being piped and handle errors accordingly when the text argument is missing.